### PR TITLE
Fix to bug in Ablation example

### DIFF
--- a/examples/Ablation-tutorial/ablation.py
+++ b/examples/Ablation-tutorial/ablation.py
@@ -227,9 +227,6 @@ session.tui.solve.report_files.add(
 # Initialize and Save
 session.tui.solve.initialize.compute_defaults.pressure_far_field("inlet")
 
-# Initialize solver workflow
-# session.tui.solve.initialize.initialize_flow()
-
 # Save case file
 save_case_data_as = Path(save_path) / "ablation.cas.h5"
 session.tui.file.write_case(save_case_data_as)


### PR DESCRIPTION
Addresses https://github.com/pyansys/pyfluent-examples/issues/28

Now the output is the same as when loading the dat files directly, producing meaningful results (i.e. not zero everywhere). 

I've been able to pinpoint the issue to this line: https://github.com/pyansys/pyfluent-examples/blob/3fcce0e9e23c369f4cb69a07c88f5717c435f6c5/examples/Ablation-tutorial/ablation.py#L230

I believe the reason for this bug is related to the resulting simulation setup from the script being incompatible with the model choices. For example it uses zero pressure boundary conditions, but the models seem to require non-zero pressure boundary conditions. This means that solving will not work, and I guess this is the same reason why trying to initialize the solution results in weird behavior from that point onwards (only restarting the Fluent client seemed to fix this issue other than removing the mentioned initialization line). 

Tested in Fluent v231, as my Fluent v232 seems to be missing 'hsf' for this example, and I am still downloading a more updated v232 release to see if it fixes the 'hsf' issue (downloading v241 as well).
